### PR TITLE
Small copy tweaks for hiring 

### DIFF
--- a/src/case-studies/hiring.md
+++ b/src/case-studies/hiring.md
@@ -10,7 +10,7 @@ summary: Built a complete hiring engine from scratch, delivering 85% of roles wh
 
 A SaaS scale-up needed to grow fast. Leadership knew the hires they needed, but hiring was ad-hoc, interviewers were few, and no real process existed. With a fixed budget, every decision mattered.
 
-They didn’t need recruiters — they needed a trusted partner who worked as they would themselves designing, building and bootstrapping the hiring system, bringing existing staff along for the journey.  
+They didn’t need recruiters, they needed a trusted partner who worked as they would themselves designing, building and bootstrapping the hiring system, bringing existing staff along for the journey.  
 
 ---
 
@@ -24,7 +24,7 @@ We anchored workshops around three hard questions:
 \- **Where will they come from?** Agencies, agreements, targeting.
 \- **How will we choose?** Interview framework, rigour, decisions, capacity.
 
-Once agreed, we acted autonomously — updating only at key decision points while iterating the plan as new market data arrived
+Once agreed, we acted autonomously updating only at key decision points while iterating the plan as new market data arrived
 
 ---
 
@@ -32,7 +32,7 @@ Once agreed, we acted autonomously — updating only at key decision points whil
 
 ![Delivery](/assets/delivery.svg){.icon-right}
 
-\- **Boots on the ground.** We started hiring immediately — building pipelines, talking to candidates, interviewing ourselves. Senior hires landed early, boosting capacity and proving the model. AI note-taking cut admin while raising accountability.
+\- **Boots on the ground.** We started hiring immediately: building pipelines, talking to candidates, interviewing ourselves. Senior hires landed early, boosting capacity and proving the model. AI note-taking cut admin while raising accountability.
 \- **Framework.** Alongside execution, we stood up the basics: job descriptions, interview loops, scripts, rubrics, and debriefs. Lightweight but predictable, designed to train others.
 \- **Leave a working solution.** We trained staff and new senior hires to become interviewers, coached evidence-based interviewing, and transitioned ownership to in-house recruiting so the system would persist.
 

--- a/src/homepage-carousel/3-hiring.md
+++ b/src/homepage-carousel/3-hiring.md
@@ -7,4 +7,4 @@ cta:
 
 At a SaaS scale-up, growth was pressing. The client knew exactly what was needed: a significant expansion of engineering headcount. The gap was in execution capacity and rigour with few interviewers, no consistent process, and little experience of hiring at scale. The likely outcome was failure to hire fast enough, or hiring badly.
 
-We built the plan with them, then executed it alongside them aligned to their goals but without demanding their minute-to-minute involvement. Running loops, refining scripts, training interviewers, and onboarding tools, we gave them space to focus on other priorities while building their organisation’s own capacity to hire at scale.
+We built the plan with them, then executed it alongside them, aligned to their goals but without demanding their minute-to-minute involvement. Running loops, refining scripts, training interviewers, and onboarding tools, we gave them space to focus on other priorities while building their organisation’s own capacity to hire at scale.

--- a/src/homepage-carousel/3-hiring.md
+++ b/src/homepage-carousel/3-hiring.md
@@ -5,6 +5,6 @@ cta:
   link: /case-studies/hiring
 ---
 
-At a SaaS scale-up, growth was pressing. The client knew exactly what was needed: a significant expansion of engineering headcount. The gap was in execution capacity and rigour — few interviewers, no consistent process, and little experience of hiring at scale. The likely outcome was failure to hire fast enough, or hiring badly.
+At a SaaS scale-up, growth was pressing. The client knew exactly what was needed: a significant expansion of engineering headcount. The gap was in execution capacity and rigour with few interviewers, no consistent process, and little experience of hiring at scale. The likely outcome was failure to hire fast enough, or hiring badly.
 
-We built the plan with him, then executed it alongside him — aligned to his goals but without demanding his minute-to-minute involvement. Running loops, refining scripts, training interviewers, and onboarding tools, we gave him space to focus on other priorities while building his organisation’s own capacity to hire at scale.
+We built the plan with them, then executed it alongside them aligned to their goals but without demanding their minute-to-minute involvement. Running loops, refining scripts, training interviewers, and onboarding tools, we gave them space to focus on other priorities while building their organisation’s own capacity to hire at scale.


### PR DESCRIPTION
Reduction in dashes and changed client references to gender neutral in accelerate hiring narrative